### PR TITLE
Clean up Application.kt

### DIFF
--- a/src/main/kotlin/Application.kt
+++ b/src/main/kotlin/Application.kt
@@ -51,30 +51,30 @@ fun main(args: Array<String>) {
 
 val log = KotlinLogging.logger {}
 
-fun Application.module(defaultBrokerAddress: String = "tcp://localhost:1883") {
-    val discordBotToken = System.getenv("DISCORD_BOT_TOKEN")
+fun Application.module() {
     val voiceContext =
-        if (discordBotToken != null) {
-            VoiceContext.builder().token(discordBotToken).build()
-        } else {
-            log.warn { "DISCORD_BOT_TOKEN not provided. Using mock Discord integration." }
-            VoiceContext.builder().asMock().build()
-        }
+        System.getenv("DISCORD_BOT_TOKEN")?.let { VoiceContext.builder().token(it).build() }
+            ?: run {
+                log.warn { "DISCORD_BOT_TOKEN not provided, using dummy discord implementation!" }
+                VoiceContext.builder().asMock().build()
+            }
     val sampleService = voiceContext.sampleService
     val discordService = voiceContext.discordService
 
-    sampleService.readSamplesZip(javaClass.getResourceAsStream("/samples/FPS.zip"))
+    val brokerAddress = System.getenv("BROKER_ADDRESS") ?: "tcp://localhost:1883"
 
     val configs: MutableList<SampleMapper> = ArrayList()
 
+    // Add default samples
+    sampleService.readSamplesZip(javaClass.getResourceAsStream("/samples/FPS.zip"))
     configs.add(
         SampleMapper.constructSampleMapper(
             javaClass.getResourceAsStream("/samples/FPS.mapping.json")!!
         )
     )
 
+    // Add custom samples
     System.getenv("SAMPLE_DIR")?.let { sampleDir -> sampleService.readSamples(sampleDir) }
-
     System.getenv("SAMPLE_MAPPING_DIR")?.let { sampleMappingDir ->
         File(sampleMappingDir)
             .walkTopDown()
@@ -88,20 +88,25 @@ fun Application.module(defaultBrokerAddress: String = "tcp://localhost:1883") {
         System.getenv("DISCORD_VOICE_CHANNEL_ID")?.let {
             discordService.getVoiceChannel(it.toLong())
         }
-    if (voiceChannel == null) {
-        log.warn { "DISCORD_VOICE_CHANNEL_ID not provided. Voice functionality will be limited." }
-    }
-    val timeService = TimeServiceImpl()
-
-    val samplePlayer = SamplePlayer(discordService, voiceChannel)
-
-    moduleWithDependencies(samplePlayer, configs, defaultBrokerAddress, timeService, sampleService)
+            ?: run {
+                log.warn {
+                    "DISCORD_VOICE_CHANNEL_ID not provided. Voice functionality will be limited."
+                }
+                null
+            }
+    moduleWithDependencies(
+        samplePlayer = SamplePlayer(discordService, voiceChannel),
+        configs = configs,
+        brokerAddress = brokerAddress,
+        timeService = TimeServiceImpl(),
+        sampleService = sampleService,
+    )
 }
 
 fun Application.moduleWithDependencies(
     samplePlayer: SamplePlayer,
     configs: MutableList<SampleMapper>,
-    defaultBrokerAddress: String,
+    brokerAddress: String,
     timeService: TimeService,
     sampleService: SampleService,
     msgProcessed: ((msg: String) -> Unit) = {},
@@ -139,13 +144,7 @@ fun Application.moduleWithDependencies(
             .add(SsePublisher(gameStateRepository))
             .build()
     try {
-        MessagingClient(
-            eventHandler,
-            System.getenv("BROKER_ADDRESS") ?: defaultBrokerAddress,
-            timeService,
-            gameStateRepository,
-            msgProcessed,
-        )
+        MessagingClient(eventHandler, brokerAddress, timeService, gameStateRepository, msgProcessed)
     } catch (ex: Exception) {
         log.error(ex) { "could not connect to broker" }
         throw ex

--- a/src/main/kotlin/messaging/MessageInterpreter.kt
+++ b/src/main/kotlin/messaging/MessageInterpreter.kt
@@ -94,7 +94,7 @@ class MessageInterpreter(
 
     fun parseStatfeedEvent(dataStr: String): StatMessage? {
         val src = json.decodeFromString<JsonStatfeedEventData>(dataStr)
-        val event = StatEvents.entries.find { it.eq(src.eventName) }
+        val event = StatEvents.of(src.eventName)
         if (event == null) {
             log.info { "Event \"${src.eventName}\" not supported." }
             return null
@@ -154,8 +154,8 @@ class MessageInterpreter(
 
     fun parseOtherGameEvent(gameEvent: String, dataStr: String): GameEventMessage? {
         val data = json.decodeFromString<JsonMatchGuidData>(dataStr)
-        val event = GameEvents.entries.find { it.eq(gameEvent) }
-        return if (event != null) GameEventMessage(matchGuid = data.matchGuid, gameEvent = event)
-        else null
+        return GameEvents.of(gameEvent)?.let {
+            GameEventMessage(matchGuid = data.matchGuid, gameEvent = it)
+        }
     }
 }

--- a/src/main/kotlin/model/SharedModel.kt
+++ b/src/main/kotlin/model/SharedModel.kt
@@ -58,6 +58,12 @@ enum class StatEvents(val eventName: String) {
     fun eq(other: String): Boolean {
         return eventName == other
     }
+
+    companion object {
+        fun of(event: String): StatEvents? {
+            return StatEvents.entries.find { it.eq(event) }
+        }
+    }
 }
 
 enum class GameEvents(val eventName: String) {
@@ -80,5 +86,11 @@ enum class GameEvents(val eventName: String) {
 
     fun eq(other: String): Boolean {
         return eventName == other
+    }
+
+    companion object {
+        fun of(event: String): GameEvents? {
+            return entries.find { it.eq(event) }
+        }
     }
 }

--- a/src/test/kotlin/ApplicationKtTest.kt
+++ b/src/test/kotlin/ApplicationKtTest.kt
@@ -27,7 +27,7 @@ class ApplicationTest : AbstractMessagingTest() {
             moduleWithDependencies(
                 samplePlayer = samplePlayer,
                 configs = configsList,
-                defaultBrokerAddress = "tcp://localhost:$mappedPort",
+                brokerAddress = "tcp://localhost:$mappedPort",
                 TimeServiceMock(),
                 voiceContext.sampleService,
             )

--- a/src/test/kotlin/integrationTests/MessagingTest.kt
+++ b/src/test/kotlin/integrationTests/MessagingTest.kt
@@ -57,7 +57,7 @@ class MessagingTest : AbstractMessagingTest() {
             moduleWithDependencies(
                 samplePlayer = SamplePlayer(voiceContext.discordService, voiceChannel),
                 configs = configsList,
-                defaultBrokerAddress = "tcp://localhost:$mappedPort",
+                brokerAddress = "tcp://localhost:$mappedPort",
                 timeServiceMock,
                 sampleService = voiceContext.sampleService,
                 { semaphore.addAndFetch(-1) },


### PR DESCRIPTION
Put all environment configuration in the same scope and prevented RLA from crashing when no discord token is supplied